### PR TITLE
允许通过闭包自定义限流响应

### DIFF
--- a/src/Throttle.php
+++ b/src/Throttle.php
@@ -11,6 +11,7 @@ use think\Container;
 use think\exception\HttpResponseException;
 use think\middleware\throttle\CounterFixed;
 use think\middleware\throttle\CounterSlider;
+use think\middleware\throttle\ThrottleAbstract;
 use think\Request;
 use think\Response;
 
@@ -60,6 +61,9 @@ class Throttle
     protected $max_requests = 0;    // 规定时间内允许的最大请求次数
     protected $expire = 0;          // 规定时间
     protected $remaining = 0;       // 规定时间内还能请求的次数
+    /**
+     * @var ThrottleAbstract
+     */
     protected $driver_class = null;
 
     public function __construct(Cache $cache, Config $config)
@@ -84,7 +88,7 @@ class Throttle
         if (null === $key) {
             return true;
         }
-        list($max_requests, $duration) = $this->parseRate($this->config['visit_rate']);
+        [$max_requests, $duration] = $this->parseRate($this->config['visit_rate']);
 
         $micronow = microtime(true);
         $now = (int) $micronow;
@@ -164,7 +168,7 @@ class Throttle
      */
     protected function parseRate($rate)
     {
-        list($num, $period) = explode("/", $rate);
+        [$num, $period] = explode("/", $rate);
         $max_requests = (int) $num;
         $duration = static::$duration[$period] ?? (int) $period;
         return [$max_requests, $duration];

--- a/src/Throttle.php
+++ b/src/Throttle.php
@@ -5,6 +5,7 @@ declare (strict_types = 1);
 namespace think\middleware;
 
 use Closure;
+use Psr\SimpleCache\CacheInterface;
 use think\Cache;
 use think\Config;
 use think\Container;
@@ -46,7 +47,7 @@ class Throttle
 
     /**
      * 缓存对象
-     * @var Cache
+     * @var CacheInterface
      */
     protected $cache;
 
@@ -63,10 +64,15 @@ class Throttle
     protected $expire = 0;          // 规定时间
     protected $remaining = 0;       // 规定时间内还能请求的次数
     /**
-     * @var ThrottleAbstract
+     * @var ThrottleAbstract|null
      */
     protected $driver_class = null;
 
+    /**
+     * Throttle constructor.
+     * @param Cache  $cache
+     * @param Config $config
+     */
     public function __construct(Cache $cache, Config $config)
     {
         $this->cache  = $cache;
@@ -167,8 +173,8 @@ class Throttle
 
     /**
      * 解析频率配置项
-     * @param $rate
-     * @return array
+     * @param string $rate
+     * @return int[]
      */
     protected function parseRate($rate)
     {
@@ -180,7 +186,7 @@ class Throttle
 
     /**
      * 设置速率
-     * @param $rate string '10/m'  '20/300'
+     * @param string $rate '10/m'  '20/300'
      * @return $this
      */
     public function setRate($rate)
@@ -191,7 +197,7 @@ class Throttle
 
     /**
      * 设置缓存驱动
-     * @param $cache
+     * @param CacheInterface $cache
      * @return $this
      */
     public function setCache($cache)
@@ -202,7 +208,8 @@ class Throttle
 
     /**
      * 设置限流算法类
-     * @param $class_name
+     * @param string $class_name
+     * @return $this
      */
     public function setDriverClass($class_name) {
         $this->config['driver_name'] = $class_name;

--- a/src/config.php
+++ b/src/config.php
@@ -13,6 +13,8 @@ return [
     'visit_rate' => '100/m',
     // 访问受限时返回的http状态码
     'visit_fail_code' => 429,
-    // 访问受限时访问的文本信息
+    // 访问受限时的响应文本信息
     'visit_fail_text' => '访问频率受到限制，请稍等__WAIT__秒再试',
+    // 访问受限时的响应信息闭包回调（优先级高于：visit_fail_text）
+    'visit_fail_response' => null,
 ];

--- a/src/throttle/ThrottleAbstract.php
+++ b/src/throttle/ThrottleAbstract.php
@@ -4,6 +4,8 @@
 namespace think\middleware\throttle;
 
 
+use Psr\SimpleCache\CacheInterface;
+
 abstract class ThrottleAbstract
 {
     protected $cur_requests = 0;    // 当前已有的请求数
@@ -11,11 +13,11 @@ abstract class ThrottleAbstract
 
     /**
      * 是否允许访问
-     * @param string $key       缓存键
-     * @param float $micronow   当前时间戳,可含毫秒
-     * @param int $max_requests 允许最大请求数
-     * @param int $duration     限流时长
-     * @param $cache            缓存对象
+     * @param string $key           缓存键
+     * @param float $micronow       当前时间戳,可含毫秒
+     * @param int $max_requests     允许最大请求数
+     * @param int $duration         限流时长
+     * @param CacheInterface $cache 缓存对象
      * @return mixed
      */
     abstract public function allowRequest(string $key, float $micronow, int $max_requests, int $duration, $cache);


### PR DESCRIPTION
throttle.php
```
return [
    // 缓存键前缀，防止键值与其他应用冲突
    'prefix' => 'throttle_',
    // 缓存的键，true 表示使用来源ip
    'key' => true,
    // 要被限制的请求类型, eg: GET POST PUT DELETE HEAD 等
    'visit_method' => ['GET', 'HEAD'],
    // 设置访问频率，例如 '10/m' 指的是允许每分钟请求10次。值 null 表示不限制， eg: null 10/m  20/h  300/d 200/300
    'visit_rate' => '3/m',
    // 访问受限时返回的http状态码
    'visit_fail_code' => 429,
    // 访问受限时访问的文本信息
    'visit_fail_text' => '访问频率受到限制，请稍等__WAIT__秒再试',
    // 访问受限时的响应信息闭包回调（优先级高于：visit_fail_text）
    'visit_fail_response' => function (Throttle $t, int $waitSeconds, Request $request) {
        return Reply::bad(1, "{$request->url()}: 访问频率受到限制，请稍等{$waitSeconds}秒再试", null, 429);
    },
];
```