### PR TITLE
消除单元测试中的警告

### DIFF
--- a/tests/Base.php
+++ b/tests/Base.php
@@ -4,7 +4,7 @@ namespace tests;
 
 use PHPUnit\Framework\TestCase;
 
-abstract class BaseTest extends TestCase {
+abstract class Base extends TestCase {
     static $ROOT_PATH = __DIR__ . "/../vendor/topthink/think";
     static $RUNTIME_PATH = __DIR__ . "/../runtime/";
 

--- a/tests/CustomCacheTest.php
+++ b/tests/CustomCacheTest.php
@@ -46,7 +46,7 @@ class DummyCache implements CacheInterface {
 }
 
 
-class CustomCacheTest extends BaseTest {
+class CustomCacheTest extends Base {
 
     function visit(int $count): int
     {

--- a/tests/ResidentMemoryTest.php
+++ b/tests/ResidentMemoryTest.php
@@ -10,7 +10,7 @@ namespace tests;
  * Class ResidentMemoryTest
  * @package tests
  */
-class ResidentMemoryTest extends BaseTest
+class ResidentMemoryTest extends Base
 {
     public function test_resident_memory()
     {

--- a/tests/ThrottleDefaultConfigTest.php
+++ b/tests/ThrottleDefaultConfigTest.php
@@ -8,7 +8,7 @@ namespace tests;
  * Class ThrottleDefaultConfig
  * @package tests
  */
-class ThrottleDefaultConfigTest extends BaseTest
+class ThrottleDefaultConfigTest extends Base
 {
     function __construct($name = null, array $data = [], $dataName = '')
     {

--- a/tests/VisitRateTest.php
+++ b/tests/VisitRateTest.php
@@ -8,7 +8,7 @@ namespace tests;
 
 use think\middleware\Throttle;
 
-class VisitRateTest extends BaseTest
+class VisitRateTest extends Base
 {
     function is_visit_allow(string $uri): bool
     {


### PR DESCRIPTION
PHPUnit 9.6.9 by Sebastian Bergmann and contributors.

Warning:       Abstract test case classes with "Test" suffix are deprecated (tests\BaseTest)